### PR TITLE
fix: Bulk Sell GUI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ allprojects {
     }
 
     dependencies {
-        compileOnly("com.willfp:eco:7.4.0")
+        compileOnly("com.willfp:eco:7.4.2")
         compileOnly("org.jetbrains:annotations:26.0.2")
         compileOnly("org.jetbrains.kotlin:kotlin-stdlib:2.3.0")
         compileOnly("com.github.ben-manes.caffeine:caffeine:3.2.3")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ allprojects {
     }
 
     dependencies {
-        compileOnly("com.willfp:eco:7.4.2")
+        compileOnly("com.willfp:eco:7.4.3")
         compileOnly("org.jetbrains:annotations:26.0.2")
         compileOnly("org.jetbrains.kotlin:kotlin-stdlib:2.3.0")
         compileOnly("com.github.ben-manes.caffeine:caffeine:3.2.3")

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoshop/commands/CommandReload.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoshop/commands/CommandReload.kt
@@ -1,6 +1,5 @@
 package com.willfp.ecoshop.commands
 
-import com.willfp.eco.core.Prerequisite
 import com.willfp.eco.core.command.impl.Subcommand
 import com.willfp.eco.util.StringUtils
 import com.willfp.eco.util.toNiceString
@@ -9,24 +8,18 @@ import com.willfp.ecoshop.shop.ShopCategories
 import com.willfp.ecoshop.shop.Shops
 import org.bukkit.command.CommandSender
 
-object CommandReload : Subcommand(
+object CommandReload: Subcommand(
     plugin,
     "reload",
     "ecoshop.command.reload",
     false
 ) {
     override fun onExecute(sender: CommandSender, args: List<String>) {
-        val runnable = Runnable {
-            sender.sendMessage(
-                plugin.langYml.getMessage("reloaded", StringUtils.FormatOption.WITHOUT_PLACEHOLDERS)
-                    .replace("%time%", plugin.reloadWithTime().toNiceString())
-                    .replace("%shops%", Shops.values().size.toString())
-                    .replace("%categories%", ShopCategories.values().size.toString())
-            )
-        }
-        if (Prerequisite.HAS_FOLIA.isMet)
-            plugin.scheduler.runTask(runnable) // run on global thread
-        else
-            runnable.run()
+        sender.sendMessage(
+            plugin.langYml.getMessage("reloaded", StringUtils.FormatOption.WITHOUT_PLACEHOLDERS)
+                .replace("%time%", plugin.reloadWithTime().toNiceString())
+                .replace("%shops%", Shops.values().size.toString())
+                .replace("%categories%", ShopCategories.values().size.toString())
+        )
     }
 }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoshop/shop/ShopItem.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoshop/shop/ShopItem.kt
@@ -608,7 +608,7 @@ fun ItemStack.sell(
     shop: Shop? = null
 ): Boolean {
     val item = this.shopItem ?: return false
-    if (item.getCurrentSellStatus(player, this.amount) != SellStatus.ALLOW) {
+    if (item.getSellStatus(player, this.amount) != SellStatus.ALLOW) {
         return false
     }
 
@@ -668,7 +668,7 @@ fun Collection<ItemStack>.sell(
             continue
         }
 
-        if (item.getCurrentSellStatus(player, itemStack.amount) != SellStatus.ALLOW) {
+        if (item.getSellStatus(player, itemStack.amount) != SellStatus.ALLOW) {
             unsold += itemStack
             continue
         }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoshop/shop/ShopItem.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoshop/shop/ShopItem.kt
@@ -608,7 +608,7 @@ fun ItemStack.sell(
     shop: Shop? = null
 ): Boolean {
     val item = this.shopItem ?: return false
-    if (item.getSellStatus(player, this.amount) != SellStatus.ALLOW) {
+    if (item.getCurrentSellStatus(player, this.amount) != SellStatus.ALLOW) {
         return false
     }
 
@@ -682,9 +682,9 @@ fun Collection<ItemStack>.sell(
             continue
         }
 
-        val price = itemStack.getUnitSellValue(player)
+        val price = item.sellPrice!!
 
-        val event = EcoShopSellEvent(player, item, item.sellPrice!!, itemStack)
+        val event = EcoShopSellEvent(player, item, price, itemStack)
         Bukkit.getPluginManager().callEvent(event)
 
         price.giveTo(player, sellableAmount.toDouble() * event.multiplier)

--- a/eco-core/core-plugin/src/main/resources/plugin.yml
+++ b/eco-core/core-plugin/src/main/resources/plugin.yml
@@ -4,8 +4,6 @@ main: com.willfp.ecoshop.EcoShopPlugin
 api-version: 1.17
 authors: [ Auxilor ]
 website: willfp.com
-folia-supported: true
-
 depend:
   - eco
 softdepend:


### PR DESCRIPTION
**Summary**
When a player opens the Quick Sell GUI (/sell) and places all of a given item type into the captive grid — leaving none remaining in their main inventory — every stack is returned via DropQueue instead of being sold. Placements of a partial amount appear to work only because the player still has some of that item in their main inventory.

**In-game testing:**
1. Configure a sellable item (e.g. grass block).
2. Give a player exactly 64 + 64 of that item and nothing else of that type.
3. Run /sell to open the Quick Sell GUI and drag both stacks into the captive grid. Close the menu.
4. Expected: player receives payment for 128 items, 0 returned. Before the fix, all 128 would be returned unsold.
5. Repeat with 64 + 15 (partial stack) to confirm mixed amounts also sell correctly.
6. Regression Test: /shop per-item sell: Open /shop, navigate to the same item, right-click into its Sell Menu. Confirm the status messages (SOLD_TOO_MANY, DONT_HAVE_ITEM, etc.) still display correctly when the player lacks the item or has hit a sell limit.
7. Regression Test: /sell all, /sellhand, /sellhandall: Run each with sellable items in inventory. Sell limits and permission checks must still be honoured.