### PR TITLE
fix: Sell Wand

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoshop/shop/ShopItem.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoshop/shop/ShopItem.kt
@@ -586,7 +586,7 @@ val ItemStack.shopItem: ShopItem?
 
 fun ItemStack.isSellable(player: Player): Boolean {
     val item = this.shopItem ?: return false
-    if (item.getCurrentSellStatus(player, this.amount) != SellStatus.ALLOW) {
+    if (item.getSellStatus(player, this.amount) != SellStatus.ALLOW) {
         return false
     }
 
@@ -595,7 +595,7 @@ fun ItemStack.isSellable(player: Player): Boolean {
 
 fun ItemStack.getUnitSellValue(player: Player): ConfiguredPrice {
     val item = this.shopItem ?: return ConfiguredPrice.FREE
-    if (item.getCurrentSellStatus(player, this.amount) != SellStatus.ALLOW) {
+    if (item.getSellStatus(player, this.amount) != SellStatus.ALLOW) {
         return ConfiguredPrice.FREE
     }
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoshop/shop/ShopItem.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoshop/shop/ShopItem.kt
@@ -608,7 +608,7 @@ fun ItemStack.sell(
     shop: Shop? = null
 ): Boolean {
     val item = this.shopItem ?: return false
-    if (item.getCurrentSellStatus(player, this.amount) != SellStatus.ALLOW) {
+    if (item.getSellStatus(player, this.amount) != SellStatus.ALLOW) {
         return false
     }
 
@@ -668,7 +668,7 @@ fun Collection<ItemStack>.sell(
             continue
         }
 
-        if (item.getCurrentSellStatus(player, itemStack.amount) != SellStatus.ALLOW) {
+        if (item.getSellStatus(player, itemStack.amount) != SellStatus.ALLOW) {
             unsold += itemStack
             continue
         }


### PR DESCRIPTION
**Summary**
Any sellwand built on eco-core's ShopIntegration API (Zach's sellwand or any other) reports every chest item as unsellable whenever EcoShop is loaded. Uninstalling EcoShop restores normal behaviour because the wand falls back to the next registered ShopIntegration. The Quick Sell GUI fix in the parent branch (fix/ecoshop_bulk_sell) does not cover this path.

**In-game testing:**

1. Install EcoShop alongside a sellwand plugin that consumes eco-core's ShopIntegration (e.g. Zach's sellwand).
2. Configure a shop item with a sell price.
3. Place a chest containing stacks of that sellable item. Look at the chest and use the sellwand.
4. Expected: the wand sells the items and pays the player at EcoShop's configured sell price. Before the fix, every item is reported unsellable and nothing is paid out.
5. Confirm EcoShop does not need to be removed for the wand to function.
6. Regression Test: Quick Sell GUI: Repeat the SellGUI test from the parent PR to confirm the .sell extension fixes are still intact.
7. Regression Test: /shop per-item sell, /sell all, /sellhand, /sellhandall: All must continue to honour sell limits, permission checks, and sell conditions as before.